### PR TITLE
fix: add Sitemap directive to robots.txt

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -120,3 +120,5 @@ Disallow: /prodimages/
 Disallow: /private/
 
 Allow: /
+
+Sitemap: https://www.scarcom.com.br/sitemap.xml


### PR DESCRIPTION
The robots.txt standardization PR was merged without a `Sitemap:` directive because the sitemap URL was not detected during the initial rollout.

This PR adds the missing directive:

```
Sitemap: https://www.scarcom.com.br/sitemap.xml
```

**Why this matters:**
- Google uses the Sitemap directive in robots.txt to discover the sitemap
- Without it, crawlers rely on guessing or Search Console configuration
- This was identified as part of a mass audit of all merged robots.txt PRs